### PR TITLE
feat: Adding support for Environments

### DIFF
--- a/.changes/unreleased/Added-20250313-214659.yaml
+++ b/.changes/unreleased/Added-20250313-214659.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Adds Environment module
+time: 2025-03-13T21:46:59.872497421Z

--- a/management/environment.go
+++ b/management/environment.go
@@ -1,0 +1,147 @@
+package management
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+type EnvironmentResponse struct {
+	Environment Environment `json:"environment"`
+}
+
+type EnvironmentRequest struct {
+	Environment EnvironmentInput `json:"environment"`
+}
+
+// Environment represents the environment in contentstack
+type Environment struct {
+	CreatedAt time.Time        `json:"created_at"`
+	UpdatedAt time.Time        `json:"updated_at"`
+	Name      string           `json:"name"`
+	UID       string           `json:"uid,omitempty"`
+	URLs      []EnvironmentUrl `json:"urls"`
+}
+
+type EnvironmentUrl struct {
+	Locale string `json:"locale"`
+	URL    string `json:"url"`
+}
+
+// EnvironmentInput is used to create or update an environment
+type EnvironmentInput struct {
+	Name string           `json:"name"`
+	URLs []EnvironmentUrl `json:"urls"`
+}
+
+func (si *StackInstance) EnvironmentCreate(ctx context.Context, input EnvironmentInput) (*Environment, error) {
+	data, err := serializeInput(EnvironmentRequest{Environment: input})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := si.client.post(
+		ctx,
+		"/v3/environments/",
+		url.Values{},
+		si.headers(),
+		data,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &EnvironmentResponse{}
+	if err = si.client.processResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Environment, nil
+}
+
+func (si *StackInstance) EnvironmentUpdate(ctx context.Context, name string, input EnvironmentInput) (*Environment, error) {
+	data, err := serializeInput(EnvironmentRequest{Environment: input})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := si.client.put(
+		ctx,
+		fmt.Sprintf("/v3/environments/%s", name),
+		url.Values{},
+		si.headers(),
+		data,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &EnvironmentResponse{}
+	if err = si.client.processResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Environment, nil
+}
+
+func (si *StackInstance) EnvironmentDelete(ctx context.Context, name string) error {
+	resp, err := si.client.delete(
+		ctx,
+		fmt.Sprintf("/v3/environments/%s", name),
+		url.Values{},
+		si.headers(),
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	result := &EnvironmentResponse{}
+	if err = si.client.processResponse(resp, &result); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (si *StackInstance) EnvironmentFetch(ctx context.Context, name string) (*Environment, error) {
+	resp, err := si.client.get(
+		ctx,
+		fmt.Sprintf("/v3/environments/%s", name),
+		url.Values{},
+		si.headers(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &EnvironmentResponse{}
+	if err = si.client.processResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Environment, nil
+}
+
+func (si *StackInstance) EnvironmentFetchAll(ctx context.Context, name string) ([]Environment, error) {
+	resp, err := si.client.get(
+		ctx,
+		"/v3/environments",
+		url.Values{},
+		si.headers(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	result := struct {
+		Environments []Environment `json:"environments"`
+	}{}
+
+	if err = si.client.processResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return result.Environments, nil
+}


### PR DESCRIPTION
This PR adds support for [environments](https://www.contentstack.com/docs/developers/apis/content-management-api#environment) in ContentStack. 

I'm adding this as I would like to add support for Environments in the [terraform provider](https://github.com/labd/terraform-provider-contentstack)

### NEW FEATURES

- Adds support for Environment CRUD operations

---

Please note, I'm not a Go developer and have copied the style from around the rest of the module. If there's anything I've missed please point it out and I shall correct it 😄 
