### PR TITLE
feat: add notifiers field to webhook structs

### DIFF
--- a/.changes/unreleased/Added-20260603-143053.yaml
+++ b/.changes/unreleased/Added-20260603-143053.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added Notifiers field to WebHook and WebHookInput structs to support email notification on circuit breaker events
+time: 2026-06-03T14:30:53.347423+01:00

--- a/management/webhook.go
+++ b/management/webhook.go
@@ -30,6 +30,7 @@ type WebHook struct {
 	RetryPolicy     string               `json:"retry_policy"`
 	Disabled        bool                 `json:"disabled"`
 	ConcisePayload  bool                 `json:"concise_payload"`
+	Notifiers       []string             `json:"notifiers"`
 }
 
 type WebhookDestination struct {
@@ -53,6 +54,7 @@ type WebHookInput struct {
 	RetryPolicy    string               `json:"retry_policy"`
 	Disabled       bool                 `json:"disabled"`
 	ConcisePayload bool                 `json:"concise_payload"`
+	Notifiers      []string             `json:"notifiers"`
 }
 
 func (si *StackInstance) WebHookCreate(ctx context.Context, input WebHookInput) (*WebHook, error) {

--- a/management/webhook_test.go
+++ b/management/webhook_test.go
@@ -1,0 +1,54 @@
+package management
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestWebHookInput_NotifiersSerializedToJSON(t *testing.T) {
+	input := WebHookRequest{
+		WebHook: WebHookInput{
+			Name:      "test-hook",
+			Notifiers: []string{"ops@example.com", "dev@example.com"},
+		},
+	}
+	data, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	webhook, ok := result["webhook"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected webhook key in JSON")
+	}
+	notifiers, ok := webhook["notifiers"].([]interface{})
+	if !ok {
+		t.Fatalf("expected notifiers to be an array, got: %v", webhook["notifiers"])
+	}
+	if len(notifiers) != 2 {
+		t.Errorf("expected 2 notifiers, got %d", len(notifiers))
+	}
+	if notifiers[0].(string) != "ops@example.com" {
+		t.Errorf("expected ops@example.com, got %s", notifiers[0])
+	}
+	if notifiers[1].(string) != "dev@example.com" {
+		t.Errorf("expected dev@example.com, got %s", notifiers[1])
+	}
+}
+
+func TestWebHook_NotifiersDeserializedFromJSON(t *testing.T) {
+	raw := `{"webhook":{"name":"test","notifiers":["ops@example.com"]}}`
+	var result WebHookResponse
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if len(result.WebHook.Notifiers) != 1 {
+		t.Errorf("expected 1 notifier, got %d", len(result.WebHook.Notifiers))
+	}
+	if result.WebHook.Notifiers[0] != "ops@example.com" {
+		t.Errorf("expected ops@example.com, got %s", result.WebHook.Notifiers[0])
+	}
+}


### PR DESCRIPTION
## Summary

- Add `Notifiers []string` to `WebHook` struct for reading notifiers from API responses
- Add `Notifiers []string` to `WebHookInput` struct for sending notifiers to the API
- Add JSON serialization/deserialization tests

The `notifiers` field holds up to 10 email addresses that Contentstack notifies when the Webhook Circuit Breaker disables a webhook.

Required by: labd/terraform-provider-contentstack — webhook notifiers support

## Test plan
- [ ] `go test ./management/... -run TestWebHook` passes
- [ ] `go test ./management/...` passes with no regressions